### PR TITLE
Initialize Flowbite component in HeaderWorkspace.vue

### DIFF
--- a/taskCraft_app/src/components/Header/HeaderComponents/HeaderWorkspace.vue
+++ b/taskCraft_app/src/components/Header/HeaderComponents/HeaderWorkspace.vue
@@ -1,7 +1,8 @@
 <script setup>
 import {useWorkspaceStore} from "@/stores/useWorkspaceStore.js";
-import {computed} from "vue";
+import {computed, onMounted} from "vue";
 import {useRouter} from "vue-router";
+import {initFlowbite} from "flowbite";
 
 const emit = defineEmits(['showModal', 'hideModal'])
 
@@ -9,6 +10,10 @@ const emit = defineEmits(['showModal', 'hideModal'])
 const workspace = useWorkspaceStore()
 const hasWorkspace = computed(() => workspace.workspaces.length)
 const router = useRouter()
+
+onMounted(() => {
+  initFlowbite()
+})
 
 // Methods
 const handleWorkspaceModal = () => {


### PR DESCRIPTION
Added `onMounted` lifecycle hook to initialize Flowbite components when the HeaderWorkspace.vue component is mounted. This ensures that any Flowbite-related UI interactions work correctly upon component render.