### PR TITLE
Add reinitialization of currentWorkspace if already set

### DIFF
--- a/taskCraft_app/src/stores/useWorkspaceStore.js
+++ b/taskCraft_app/src/stores/useWorkspaceStore.js
@@ -56,6 +56,10 @@ export const useWorkspaceStore = defineStore('workspace', {
 
     initWorkspaces(data) {
       this.workspaces = data
+      if (this.currentWorkspace) {
+        this.currentWorkspace = this.workspaces.find((work) => work.id === this.currentWorkspace.id)
+      }
+
     },
 
     initCurrentWorkspace(name) {


### PR DESCRIPTION
Enhanced the `initWorkspaces` method to reassign `currentWorkspace` based on updated workspaces data if `currentWorkspace` is already defined. Also, added two new images to the public directory.