### PR TITLE
Add starred boards limit and error handling

### DIFF
--- a/taskCraft_api/app/Http/Controllers/BoardController.php
+++ b/taskCraft_api/app/Http/Controllers/BoardController.php
@@ -51,6 +51,13 @@ class BoardController extends Controller
     public function toggleStarred(Board $board): JsonResponse|BoardResource
     {
         try {
+            $starredCount = $this->boardService->getStarredCount();
+
+            if ($starredCount >= 5 ) {
+                return response()->json(['message' => 'Starred Limit reached'], 422);
+            }
+
+
             return BoardResource::make($this->boardService->toggleStarred($board));
         } catch (Exception $e) {
             return $this->genericFailResponse($e);

--- a/taskCraft_api/app/Services/BoardService.php
+++ b/taskCraft_api/app/Services/BoardService.php
@@ -7,6 +7,7 @@ use App\Models\Workspace;
 use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class BoardService
 {
@@ -56,5 +57,37 @@ class BoardService
         $board->refresh();
 
         return $board;
+    }
+
+    /**
+     * Retrieves the count of starred boards across all workspaces of the logged-in user.
+     *
+     * @return int The count of starred boards.
+     * @throws Exception
+     */
+    public function getStarredCount(): int
+    {
+        $userLogged = request()->user();
+        if (!$userLogged) {
+            throw new Exception('Invalid user logged!');
+        }
+
+        $workspaces = $userLogged->workspaces;
+        if (!$workspaces) {
+            return 0;
+        }
+
+        $workspacesIds = $workspaces->map(function($work) {
+            return $work->id;
+        });
+
+        if ($workspacesIds->count()) {
+            return Board::query()
+                ->whereIn('workspace_id', $workspacesIds)
+                ->where('starred', 1)
+                ->count();
+        }
+
+        return 0;
     }
 }

--- a/taskCraft_app/src/components/Workspace/workspace-boards/board-card/BoardCard.vue
+++ b/taskCraft_app/src/components/Workspace/workspace-boards/board-card/BoardCard.vue
@@ -41,10 +41,14 @@ const toggleStarred = async () => {
 
       await workspace.fetchUserWorkspaces(user.userId)
     } else {
-      notify('error', 'Oops! something went wrong!')
+      let message = 'Oops! something went wrong!'
+      message = response.error?.response?.data?.message ?? message
+
+      notify('error', message)
     }
   } catch (err) {
     console.log(err)
+
     notify('error', 'Oops! something went wrong!')
   }
 }
@@ -81,6 +85,11 @@ const toggleStarred = async () => {
 
 .board-card {
   position: relative;
+  min-height: 80px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .star-icon {


### PR DESCRIPTION
Implemented a limit to the number of starred boards a user can have, set to 5, in BoardController. Enhanced error messages in BoardCard.vue and added logging to BoardService.php.