### PR TITLE
Fix routing to 'logout' by correcting case discrepancy

### DIFF
--- a/taskCraft_app/src/services/axios.js
+++ b/taskCraft_app/src/services/axios.js
@@ -35,7 +35,7 @@ TASKCRAFT_API.interceptors.response.use(
         return await router.push({ name: 'maintenance' })
       }
 
-      return await router.push({ name: 'Logout' })
+      return await router.push({ name: 'logout' })
     }
 
     return { error }


### PR DESCRIPTION
Previously, the router was directed to 'Logout', which caused a routing issue due to case sensitivity. Changing it to 'logout' resolves the problem and ensures proper navigation within the application.