### PR TITLE
Add starred boards feature

### DIFF
--- a/taskCraft_api/app/Services/BoardService.php
+++ b/taskCraft_api/app/Services/BoardService.php
@@ -9,7 +9,6 @@ use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 
 class BoardService
 {
@@ -91,6 +90,8 @@ class BoardService
         }
 
         return StarredUserBoard::query()
-            ->where('user_id', Auth::user()->id)->count() ?? 0;
+            ->where('user_id', Auth::user()->id)
+            ->where('is_starred', 1)
+            ->count() ?? 0;
     }
 }

--- a/taskCraft_app/src/components/Header/Header.vue
+++ b/taskCraft_app/src/components/Header/Header.vue
@@ -5,6 +5,7 @@ import CreateWorkspaceModal from "@/components/modals/Workspace/CreateWorkspaceM
 import {useUserStore} from "@/stores/useUserStore.js";
 import HeaderWorkspace from "@/components/Header/HeaderComponents/HeaderWorkspace.vue";
 import ProfileImage from "@/components/Profile/profile-images/ProfileImage.vue";
+import HeaderStarredBoards from "@/components/Header/HeaderComponents/HeaderStarredBoards.vue";
 
 // Data
 const dropdownOpen = ref(false)
@@ -135,12 +136,7 @@ const showWorkspaceModal = () => {
             </div>
           </li>
           <li>
-            <a
-              href="#"
-              class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-info-700 md:p-1 dark:text-white md:dark:hover:bg-gray-700 dark:hover:bg-gray-700 dark:hover:text-green-500 md:dark:hover:bg-gray-700"
-            >
-              Starred
-            </a>
+            <HeaderStarredBoards />
           </li>
           <li>
             <div class="flex items-center md:p-1">

--- a/taskCraft_app/src/components/Header/HeaderComponents/HeaderStarredBoards.vue
+++ b/taskCraft_app/src/components/Header/HeaderComponents/HeaderStarredBoards.vue
@@ -1,0 +1,88 @@
+<script setup>
+import {useWorkspaceStore} from "@/stores/useWorkspaceStore.js";
+import {computed, onMounted} from "vue";
+import {useRouter} from "vue-router";
+import {initFlowbite} from "flowbite";
+import {useUserStore} from "@/stores/useUserStore.js";
+
+// Data
+const workspace = useWorkspaceStore()
+const hasStarredBoards = computed(() => workspace.starredBoard.length)
+const router = useRouter()
+const user = useUserStore()
+
+onMounted(() => {
+  initFlowbite()
+})
+
+const handleRedirectBoard = (star) => {
+  console.log(star)
+}
+
+
+</script>
+
+<template>
+  <div class="header__workspace-container">
+    <button
+      data-dropdown-toggle="dropdown-starred"
+      id="dropdownNavbarLink"
+      class="flex items-center justify-between w-full py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-info-700 md:p-1 md:w-auto dark:text-white md:dark:hover:bg-gray-700 dark:focus:text-white dark:border-gray-700 dark:hover:bg-gray-700 md:dark:hover:bg-gray-700 dark:hover:text-green-500"
+    >
+      Starred
+      <svg
+        class="w-2.5 h-2.5 ms-2.5"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 10 6"
+      >
+        <path
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="m1 1 4 4 4-4"
+        />
+      </svg>
+    </button>
+    <div
+      class="z-50 hidden my-4 text-base list-none bg-white divide-y divide-gray-100 rounded shadow dark:bg-gray-700 dark:divide-gray-600"
+      id="dropdown-starred"
+    >
+      <div class="py-1" role="none" v-if="!hasStarredBoards" >
+        <p
+          class="px-4 py-2 flex flex-col text-sm text-gray-700 dark:text-white"
+          role="none"
+        >
+          <span >No Starred Board Yet</span>
+        </p>
+      </div>
+      <ul class="py-1" role="none" v-else>
+        <li
+          v-for="star in workspace.starredBoard"
+          :key="star.id"
+          @click="handleRedirectBoard(star)"
+        >
+          <a
+            class="flex flex-col hand px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-600 dark:hover:text-green-500"
+            role="menuitem"
+          >
+            {{ star.title }}
+            <small v-if="star.description">{{ star.description }}</small>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+#dropdown-workspace {
+  min-width: 150px
+}
+
+.hand {
+  cursor: pointer;
+}
+</style>

--- a/taskCraft_app/src/components/Workspace/workspace-boards/board-card/BoardCard.vue
+++ b/taskCraft_app/src/components/Workspace/workspace-boards/board-card/BoardCard.vue
@@ -34,7 +34,10 @@ const bgComputed = computed(() => {
 const handleMouseEnter = () => isHovered.value = true;
 const handleMouseLeave = () => isHovered.value = false;
 
-const toggleStarred = async () => {
+const toggleStarred = async (event) => {
+  event.stopPropagation();
+  console.log('click')
+
   try {
     const response = await board.toggleStarred(props.workspaceBoard.id, !props.workspaceBoard.starred)
 
@@ -74,21 +77,26 @@ const handleBoardClick = async () => {
       :class="bgComputed"
       @mouseenter="handleMouseEnter"
       @mouseleave="handleMouseLeave"
-      @click="handleBoardClick()"
+      @click="handleBoardClick"
     >
       {{ workspaceBoard.title }}
     </div>
-    <SolidStarIcon
+    <button
       v-if="workspaceBoard.starred"
-      class="star-icon"
       @click="toggleStarred"
-    />
+      class="star-icon"
+    >
+      <SolidStarIcon />
+    </button>
 
-    <OutlineStarIcon
-      v-if="!workspaceBoard.starred && isHovered"
-      class="star-icon"
+    <button
       @click="toggleStarred"
-    />
+      v-if="!workspaceBoard.starred "
+      class="star-icon"
+    >
+      <OutlineStarIcon />
+    </button>
+
   </div>
 
 

--- a/taskCraft_app/src/components/icon/OutlineStarIcon.vue
+++ b/taskCraft_app/src/components/icon/OutlineStarIcon.vue
@@ -6,7 +6,10 @@ defineComponent({
 });
 </script>
 <template>
-  <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+  <svg
+    @click="$emit('click', $event)"
+    xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"
+  >
     <path fill="none" stroke="#bbbbec" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.56.56 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.56.56 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.56.56 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.56.56 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.56.56 0 0 0 .475-.345z" />
   </svg>
 </template>

--- a/taskCraft_app/src/components/icon/SolidStarIcon.vue
+++ b/taskCraft_app/src/components/icon/SolidStarIcon.vue
@@ -4,9 +4,14 @@ import { defineComponent } from 'vue';
 defineComponent({
   name: 'HeroiconsStarSolid',
 });
+
+
 </script>
 <template>
-  <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+  <svg
+    @click="$emit('click', $event)"
+    xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"
+  >
     <path
       fill="#f1b900"
       fill-rule="evenodd"

--- a/taskCraft_app/src/stores/useWorkspaceStore.js
+++ b/taskCraft_app/src/stores/useWorkspaceStore.js
@@ -74,6 +74,24 @@ export const useWorkspaceStore = defineStore('workspace', {
 
     async registerAndJoin({name, email, password, workspace}) {
       return await WorkspaceService.registerAndJoin({name, email, password, workspace})
+    },
+  },
+
+  getters: {
+    starredBoard() {
+      let userStarredBoards = []
+
+      this.workspaces.forEach((workspace) => {
+        if (workspace.boards) {
+          workspace.boards.forEach((board) => {
+            if (board.starred === true) {
+              userStarredBoards.push(board)
+            }
+          })
+        }
+      })
+
+      return userStarredBoards
     }
   }
 })


### PR DESCRIPTION
Removed unnecessary logging in BoardService and updated the counting logic to include only starred boards. Enhanced Vue components to display a list of starred boards in the header and allow users to toggle the starred status on board cards.