### PR TITLE
Fix workspace selection for recent and starred boards

### DIFF
--- a/taskCraft_app/src/components/Header/HeaderComponents/HeaderRecent.vue
+++ b/taskCraft_app/src/components/Header/HeaderComponents/HeaderRecent.vue
@@ -17,7 +17,7 @@ const hasRecentBoards = computed(() => workspace.recentBoards.length)
 
 const handleRedirectRecent = async (recent) => {
   dropdownRecent.value = false
-  workspace.setCurrentWorkSpace(workspace.workspaces.find(work => work.id === recent.id))
+  workspace.setCurrentWorkSpace(workspace.workspaces.find(work => work.id === recent.workspace_id))
   board.initCurrentBoard(recent)
 
   return await router.push(`/board/${recent.id}`)

--- a/taskCraft_app/src/components/Header/HeaderComponents/HeaderStarredBoards.vue
+++ b/taskCraft_app/src/components/Header/HeaderComponents/HeaderStarredBoards.vue
@@ -17,7 +17,11 @@ const dropdownClasses = computed(() => {
 
 const handleRedirectBoard = async (star) => {
   dropdownStarred.value = false
-  workspace.setCurrentWorkSpace(workspace.workspaces.find(work => work.id === star.id))
+
+  const current = workspace.workspaces.find((work) => {
+    return work.id === star.workspace_id
+  })
+  workspace.setCurrentWorkSpace(current)
   board.initCurrentBoard(star)
 
   await workspace.saveRecentBoard(star.id)


### PR DESCRIPTION
Update functions to select the correct workspace using `workspace_id` instead of `id`. This ensures the accurate setting of the current workspace when redirecting to recent or starred boards.