### PR TITLE
Add middleware for exception handling and event broadcasting

### DIFF
--- a/taskCraft_api/app/Events/TestBroadcast.php
+++ b/taskCraft_api/app/Events/TestBroadcast.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class TestBroadcast implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public string $message;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(string $message)
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new Channel('test-channel'),
+        ];
+    }
+
+    public function broadcastWith(): array
+    {
+        return ['message' => $this->message];
+    }
+
+}

--- a/taskCraft_api/app/Http/Middleware/HandleExceptions.php
+++ b/taskCraft_api/app/Http/Middleware/HandleExceptions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Http\Traits\FailResponseTrait;
+use Closure;
+use Exception;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class HandleExceptions
+{
+    use FailResponseTrait;
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        try {
+            return $next($request);
+        } catch (Exception $e) {
+            return $this->genericFailResponse($e);
+        }
+    }
+}

--- a/taskcraft_app/package-lock.json
+++ b/taskcraft_app/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Introduced `HandleExceptions` middleware to handle request exceptions using a generic fail response. Added `TestBroadcast` event to broadcast messages on the 'test-channel'. Included an initial `package-lock.json` for dependency management.