### PR TITLE
Add observer functionality to Task model

### DIFF
--- a/taskCraft_api/app/Console/Commands/SendInvitationEmails.php
+++ b/taskCraft_api/app/Console/Commands/SendInvitationEmails.php
@@ -53,7 +53,6 @@ class SendInvitationEmails extends Command
     private function processInvitation(Invitation $invitation)
     {
         $user = User::query()->where('email', $invitation->invitee_email)->first();
-
         if ($user) {
             $this->sendInternalInvitation($user, $invitation);
         } else {

--- a/taskCraft_api/app/Models/Task.php
+++ b/taskCraft_api/app/Models/Task.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Observers\Task\TaskObserver;
+use App\Traits\RegisterObserverTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,6 +11,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Task extends Model
 {
+    use RegisterObserverTrait;
+
     /** @use HasFactory<\Database\Factories\TaskFactory> */
     use HasFactory;
 
@@ -25,6 +29,11 @@ class Task extends Model
         'due_date',
         'position'
     ];
+
+    public static function getObserverClass() : TaskObserver
+    {
+        return new TaskObserver();
+    }
 
     /**
      * Board List relationship.
@@ -59,5 +68,4 @@ class Task extends Model
     {
         return $this->hasOne(TaskChecklist::class, 'task_id', 'id');
     }
-
 }

--- a/taskCraft_api/app/Models/User.php
+++ b/taskCraft_api/app/Models/User.php
@@ -82,6 +82,7 @@ class User extends Authenticatable
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
+            ->useLogName('UserLog')
             ->logOnly(['name', 'email']);
     }
 }

--- a/taskCraft_api/app/Observers/Observer.php
+++ b/taskCraft_api/app/Observers/Observer.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Observers;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class Observer
+{
+    /**
+     * Creates a new record using the given model instance.
+     *
+     * @param mixed $model The model instance to be used for creating a new record.
+     */
+    abstract public function creating($model);
+
+    /**
+     * Performs actions when a new model is created.
+     *
+     * @param Model $model The model that has been created
+     */
+    abstract public function created($model);
+
+    /**
+     * Updates the given model in the system.
+     *
+     * @param mixed $model The model to be updated
+     */
+    abstract public function updating($model);
+
+    /**
+     * Updates the specified model.
+     *
+     * @param mixed $model The model to be updated.
+     */
+    abstract public function updated($model);
+
+    /**
+     * Deletes the specified model.
+     *
+     * @param mixed $model The model to be deleted.
+     */
+    abstract public function deleting($model);
+
+    /**
+     * Deletes the specified model.
+     *
+     * @param mixed $model The model to be deleted.
+     */
+    abstract public function deleted($model);
+
+}

--- a/taskCraft_api/app/Observers/Task/TaskObserver.php
+++ b/taskCraft_api/app/Observers/Task/TaskObserver.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Observers\Task;
+
+use App\Observers\Observer;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+class TaskObserver extends Observer
+{
+
+    public function creating($model)
+    {
+        // TODO: Implement creating() method.
+    }
+
+    /**
+     * Logs an activity for the creation of a task.
+     *
+     * @param mixed $model The task model to perform the activity on.
+     * @return void
+     */
+    public function created($model): void
+    {
+        activity()
+            ->causedBy(Auth::user())
+            ->performedOn($model)
+            ->withProperties($model->toArray())
+            ->log('Task Created');
+    }
+
+    public function updating($model)
+    {
+        // TODO: Implement updating() method.
+    }
+
+    public function updated($model): void
+    {
+        if ($model->isDirty()) {
+            $noNeededAttr = ['updated_at'];
+
+            $changes = $model->getChanges();
+            foreach($changes as $key=>$change) {
+                if (!in_array($key, $noNeededAttr)) {
+                    activity()
+                        ->causedBy(Auth::user())
+                        ->performedOn($model)
+                        ->withProperties(['new' => [$key => $change], 'old' => [$key => $model->getOriginal()[$key]] ])
+                        ->log('Task Created');
+                }
+            }
+
+        }
+    }
+
+    public function deleting($model)
+    {
+        // TODO: Implement deleting() method.
+    }
+
+    public function deleted($model)
+    {
+        // TODO: Implement deleted() method.
+    }
+}

--- a/taskCraft_api/app/Traits/RegisterObserverTrait.php
+++ b/taskCraft_api/app/Traits/RegisterObserverTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Traits;
+
+trait RegisterObserverTrait
+{
+    public static function boot(): void
+    {
+        $observedClass = self::getObserverClass();
+        parent::boot();
+        self::observe($observedClass);
+    }
+}


### PR DESCRIPTION
Introduced a RegisterObserverTrait and an abstract Observer class that TaskObserver extends. The Task model now uses RegisterObserverTrait to implement observer registration, enabling activity logging for task creation and updates.