### PR TITLE
Add Board CRUD event broadcasting and handling

### DIFF
--- a/taskCraft_api/app/Broadcasting/CreatedBoardChannel.php
+++ b/taskCraft_api/app/Broadcasting/CreatedBoardChannel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Broadcasting;
+
+use App\Models\User;
+use App\Models\WorkspaceUser;
+
+class CreatedBoardChannel
+{
+    public function __construct() {}
+
+    public function join(User $user, string $workspaceId): bool
+    {
+        return WorkspaceUser::query()
+            ->where('user_id', $user->id)
+            ->where('workspace_id', $workspaceId)
+            ->exists();
+    }
+}

--- a/taskCraft_api/app/Events/BoardCreated.php
+++ b/taskCraft_api/app/Events/BoardCreated.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Events;
+
+use App\Http\Resources\BoardResource;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class BoardCreated implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use InteractsWithSockets;
+
+    public BoardResource $board;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(Model $board)
+    {
+        $this->dontBroadcastToCurrentUser();
+        $this->board = new BoardResource($board);
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('created_board.' . $this->board->workspace_id),
+        ];
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'board' => $this->board->toArray(request())
+        ];
+    }
+}

--- a/taskCraft_api/app/Events/BoardUpdated.php
+++ b/taskCraft_api/app/Events/BoardUpdated.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Events;
+
+use App\Http\Resources\BoardResource;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class BoardUpdated implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public BoardResource $board;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(Model $board)
+    {
+        $this->board = new BoardResource($board);
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('updated_board.' . $this->board->id),
+        ];
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'board' => $this->board->toArray(request())
+        ];
+    }
+}

--- a/taskCraft_api/app/Models/Board.php
+++ b/taskCraft_api/app/Models/Board.php
@@ -2,6 +2,9 @@
 
 namespace App\Models;
 
+use App\Observers\Board\BoardObserver;
+use App\Observers\Workspace\WorkspaceObserver;
+use App\Traits\RegisterObserverTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Board extends Model
 {
     /** @use HasFactory<\Database\Factories\BoardFactory> */
-    use HasFactory;
+    use HasFactory, RegisterObserverTrait;
     protected $table = 'boards';
 
     protected $fillable = [
@@ -18,6 +21,14 @@ class Board extends Model
         'workspace_id',
         'visibility',
     ];
+
+    /**
+     * @return BoardObserver
+     */
+    public static function getObserverClass(): BoardObserver
+    {
+        return new BoardObserver();
+    }
 
     /**
      * Get the workspace that this entity belongs to.

--- a/taskCraft_api/app/Observers/Board/BoardObserver.php
+++ b/taskCraft_api/app/Observers/Board/BoardObserver.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Observers\Board;
+
+use App\Events\BoardCreated;
+use App\Observers\Observer;
+use Exception;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+class BoardObserver extends Observer
+{
+
+    public function creating($model)
+    {
+        // TODO: Implement creating() method.
+    }
+
+    /**
+     * Logs an activity for the creation of a task.
+     *
+     * @param mixed $model The task model to perform the activity on.
+     * @return void
+     */
+    public function created($model): void
+    {
+        activity()
+            ->causedBy(Auth::user())
+            ->performedOn($model)
+            ->withProperties($model->toArray())
+            ->log('Board Created');
+
+        broadcast(new BoardCreated($model));
+    }
+
+    public function updating($model)
+    {
+        // TODO: Implement updating() method.
+    }
+
+    public function updated($model): void
+    {
+        try {
+            (new HandleBoardUpdatedEvent($model))->handle();
+        } catch (Exception $e) {
+            Log::info('Observer Error', [$e->getMessage()]);
+        }
+    }
+
+    public function deleting($model)
+    {
+        // TODO: Implement deleting() method.
+    }
+
+    public function deleted($model): void
+    {
+        activity()
+            ->causedBy(Auth::user())
+            ->performedOn($model)
+            ->withProperties($model->toArray())
+            ->log('Workspace Deleted');
+    }
+}

--- a/taskCraft_api/app/Observers/Board/HandleBoardUpdatedEvent.php
+++ b/taskCraft_api/app/Observers/Board/HandleBoardUpdatedEvent.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Observers\Board;
+
+use App\Events\BoardUpdated;
+use App\Models\BoardList;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+
+class HandleBoardUpdatedEvent
+{
+    private Model $model;
+
+    public function __construct(Model $model)
+    {
+        $this->model = $model;
+    }
+
+    public function handle(): void
+    {
+        if ($this->model->isDirty()) {
+            $noNeededAttr = ['updated_at'];
+
+            $changes = $this->model->getChanges();
+            foreach($changes as $key=>$change) {
+                if (!in_array($key, $noNeededAttr)) {
+                    activity()
+                        ->causedBy(Auth::user())
+                        ->performedOn($this->model)
+                        ->withProperties([
+                            'new' => [$key => $change],
+                            'old' => [$key => $this->model->getOriginal()[$key]],
+                            'logMessage' => $this->handleMessage($key, $this->model->getOriginal()[$key], $change )
+                        ])
+                        ->log('Board Updated');
+                }
+            }
+
+            broadcast(new BoardUpdated($this->model))->toOthers();
+        }
+    }
+
+
+    private function handleMessage($key, $original, $new): string
+    {
+        switch($key) {
+            case('start_date'):
+            case('due_date'):
+                $dateKey = ucwords(str_replace('_', ' ', $key));
+                $formattedOriginal = Carbon::parse($original)->format('m/d/Y');
+                $formattedNew = Carbon::parse($new)->format('m/d/Y');
+                return "$dateKey changed from {$formattedOriginal} to $formattedNew";
+            case('priority'):
+                return "Priority changed from $original to $new";
+            case('list_id'):
+                $originalList = BoardList::query()->find($original);
+                $newList = BoardList::query()->find($new);
+
+                return "Task moved from {$originalList->title} list to {$newList->title} list";
+            default:
+                return "$key changed from $original to $new";
+        }
+    }
+
+}

--- a/taskCraft_api/routes/channels.php
+++ b/taskCraft_api/routes/channels.php
@@ -1,14 +1,16 @@
 <?php
 
+use App\Broadcasting\CreatedBoardChannel;
 use App\Broadcasting\WorkspaceChannel;
 use Illuminate\Support\Facades\Broadcast;
-use Illuminate\Support\Facades\Log;
 
 Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
 });
 
 Broadcast::channel('workspace.{workspaceId}', WorkspaceChannel::class, ['guards' => ['web', 'admin']]);
+Broadcast::channel('created_board.{workspaceId}', CreatedBoardChannel::class, ['guards' => ['web', 'admin']]);
+
 
 Broadcast::channel('test-channel', function($user){
     return true;

--- a/taskCraft_app/src/plugins/listenChannels.js
+++ b/taskCraft_app/src/plugins/listenChannels.js
@@ -5,8 +5,7 @@ export default function listenChannels() {
   const listenPublicChannels = () => {
     window.Echo.channel('test-channel')
       .listen('TestBroadcast', (e) => {
-        message.value = e.message
-        console.log('Event received: ', e)
+        console.log('Event received: ', e.message)
       })
   }
 
@@ -16,6 +15,11 @@ export default function listenChannels() {
     window.Echo.private(`workspace.${workspaceId}`)
       .listen('WorkspaceUpdated', (event) => {
         workspace.updateWorkspaceFromBroadcast(event)
+      })
+
+    window.Echo.private(`created_board.${workspaceId}`)
+      .listen('BoardCreated', (event) => {
+        workspace.addNewBoardFromBroadcast(event)
       })
   }
 

--- a/taskCraft_app/src/services/axios.js
+++ b/taskCraft_app/src/services/axios.js
@@ -12,7 +12,10 @@ const TASKCRAFT_API = axios.create({
 })
 
 TASKCRAFT_API.interceptors.request.use(
-  (request) => request,
+  (request) => {
+    request.headers['X-socket-ID'] = window.Echo.socketId()
+    return request
+  },
   (error) => error
 )
 

--- a/taskCraft_app/src/stores/useWorkspaceStore.js
+++ b/taskCraft_app/src/stores/useWorkspaceStore.js
@@ -11,8 +11,6 @@ export const useWorkspaceStore = defineStore('workspace', {
   }),
   actions: {
     updateWorkspaceFromBroadcast(event) {
-      console.log('Updating from broadcast', event)
-
       this.currentWorkspace = event.workspace
       const workspaceIndex = this.workspaces.findIndex(
         workspace => workspace.id === event.workspace.id
@@ -24,6 +22,16 @@ export const useWorkspaceStore = defineStore('workspace', {
         this.workspaces.push(event.workspace)
       }
     },
+
+    addNewBoardFromBroadcast(event) {
+      this.workspaces.forEach((workspace) => {
+        if (workspace.id === event.board.workspace_id) {
+          workspace.boards.push(event.board)
+        }
+      })
+
+    },
+
     setCurrentWorkSpace(work) {
       const user = useUserStore()
       this.currentWorkspace = work


### PR DESCRIPTION
Implement broadcasting for Board creation and updates using new BoardObserver, HandleBoardUpdatedEvent, and event classes. Add corresponding handlers in the frontend to update the workspace state upon receiving real-time board events.