### PR TITLE
Update selected task and broadcast board updates

### DIFF
--- a/taskCraft_api/app/Observers/Task/HandleTaskUpdatedEvent.php
+++ b/taskCraft_api/app/Observers/Task/HandleTaskUpdatedEvent.php
@@ -2,6 +2,7 @@
 
 namespace App\Observers\Task;
 
+use App\Events\BoardUpdated;
 use App\Models\BoardList;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
@@ -19,7 +20,6 @@ class HandleTaskUpdatedEvent
 
     public function handle(): void
     {
-        Log::info('Checking model dirty', [$this->model->isDirty()]);
         if ($this->model->isDirty()) {
             $noNeededAttr = ['updated_at'];
 
@@ -36,6 +36,14 @@ class HandleTaskUpdatedEvent
                         ])
                         ->log('Task Updated');
                 }
+            }
+
+            $boardList = BoardList::query()
+                ->with('board')
+                ->find($this->model->list_id);
+
+            if ($boardList && $boardList->board) {
+                broadcast(new BoardUpdated($boardList->board))->toOthers();
             }
         }
     }

--- a/taskCraft_app/src/stores/useBoardStore.js
+++ b/taskCraft_app/src/stores/useBoardStore.js
@@ -43,6 +43,23 @@ export const useBoardStore = defineStore('board', {
       this.visibility = board.visibility
       this.starred = board.starred
       this.lists = board.lists
+
+      if (this.selectedTask) {
+        let taskFound = null
+
+        board.lists.forEach((list) => {
+          // Find the task in the current list
+          const task = list.tasks.find(task => task.id === this.selectedTask.id)
+
+          if (task) {
+            taskFound = task
+          }
+        })
+
+        if (taskFound) {
+          this.selectedTask = taskFound
+        }
+      }
     },
 
     initCurrentBoardFromWorkspace(boardId) {


### PR DESCRIPTION
Ensure the selected task is refreshed upon board load to reflect the latest state. Additionally, broadcast updates to the board when a task is updated to notify other clients in real-time.